### PR TITLE
add support for with statement to the cd method

### DIFF
--- a/chut/__init__.py
+++ b/chut/__init__.py
@@ -676,9 +676,7 @@ class Chut(Base):
 
     def cd(self, directory):
         """Change the current directory"""
-        directory = os.path.realpath(directory)
-        os.chdir(directory)
-        env.pwd = directory
+        return ChangeDir(directory)
 
     def pwd(self):
         """return os.path.abspath(os.getcwd())"""
@@ -689,6 +687,24 @@ class Chut(Base):
 
     def ssh(self, *args):
         return SSH('ssh', *args)
+
+
+class ChangeDir:
+    """Change to a new directory and keep a track of the previous directory in
+    order to restore it. This is meant to be used in a with statement."""
+
+    def __init__(self, dir):
+        self._dir = os.path.realpath(dir)
+        self._prevdir = env.pwd
+        os.chdir(self._dir)
+        env.pwd = self._dir
+
+    def __enter__(self):
+        return self._dir
+
+    def __exit__(self, type, value, traceback):
+        os.chdir(self._prevdir)
+        env.pwd = self._prevdir
 
 
 class Command(Base):

--- a/test_chut.py
+++ b/test_chut.py
@@ -177,6 +177,12 @@ class Chut(unittest.TestCase):
         self.assertNotEqual(pwd, sh.env.pwd)
         self.assertEqual(sh.pwd(), sh.env.pwd)
         sh.cd(pwd)
+        # test with with
+        with sh.cd('..') as newd:
+            self.assertNotEqual(pwd, sh.env.pwd)
+            self.assertEqual(sh.pwd(), sh.env.pwd)
+            self.assertEqual(newd, sh.env.pwd)
+        self.assertEqual(sh.pwd(), pwd)
 
     def test_console_script(self):
         def f(args):


### PR DESCRIPTION
this is meant to be used this way:

    with cd("some/place"):
      do("something")

so the current dir is restored at the end of with block