### PR TITLE
temporarily change the env using a with statement

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -84,9 +84,19 @@ Only ``path`` return a list. Other values return a string.
 
 You can also pass a copy to your commands::
 
-  >>> env = sh.env()
+  >>> env = sh.env.copy()
   >>> sh.cat('-', env=env)
   'cat -'
+
+The environment can also be temporarily modified with a "with" statement.
+In this example, "HOME" is modified only inside the "with" block and restored
+at the end::
+
+  >>> with sh.env(HOME="/home/foo"):
+  ...     str(sh.echo("$HOME", sh=True))
+  ... 
+  '/home/foo'
+
 
 The test command
 ================

--- a/test_chut.py
+++ b/test_chut.py
@@ -35,10 +35,18 @@ class Chut(unittest.TestCase):
         self.assertEqual(str('<sh>'), repr(sh.sh))
 
     def test_environ(self):
-        env = sh.env(tmp='tmp')
+        env = sh.env.copy(tmp='tmp')
+        print(env.tmp)
         self.assertEqual(env.tmp, 'tmp')
+        self.assertEqual(sh.env.tmp, None)
         del env.tmp
         self.assertEqual(env.tmp, None)
+        with sh.env(tmp="tmp"):
+            self.assertEqual(sh.env.tmp, 'tmp')
+            with sh.env(tmp=None):
+                self.assertEqual(sh.env.tmp, None)
+            self.assertEqual(sh.env.tmp, 'tmp')
+        self.assertEqual(sh.env.tmp, None)
 
     def test_debug(self):
         sh.set_debug(False)


### PR DESCRIPTION
this should be used this way:

    with env.change(GIT_DIR=".git"):
        git("...")

however `env.change(GIT_DIR=".git")` looks a lot less natural then
`env(GIT_DIR=".git")` to me -- and I indeed already made the mistake several
time while testing the code in ipython.
Unfortunately `__call__` is already used to make a copy + modification.
Would that be possible to change the `__call__` behavior?

Also note the env.change() deals with None values in kwargs in a special way
to suppress the environment.

Your opinion on this few points would be highly appreciated!