### PR TITLE
dealing more gracefully with spaces

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -56,7 +56,7 @@ You can define some aliases::
   >>> print(repr(sh.ll('.')))
   '/usr/local/bin/ls -l .'
   >>> print(repr(sh.python('-c "import sys"')))
-  '/opt/python3/bin/python3 -c "import sys"'
+  "/opt/python3/bin/python3 -c 'import sys'"
 
 Environ
 =======

--- a/docs/ssh.rst
+++ b/docs/ssh.rst
@@ -8,7 +8,7 @@ The ssh command take a host first and is gziped by default::
     >>> from chut import ssh
     >>> srv1 = ssh('gawel@srv')
     >>> srv1.ls('~')
-    'ssh gawel@srv ls ~'
+    "ssh gawel@srv 'ls ~'"
 
 For example you can backup your mysql database locally::
 
@@ -24,6 +24,6 @@ Or on another server::
 You can use your ssh instance to get some remote file::
 
     >>> sh.rsync(srv1.join('~/p0rn'), '.', pipe=True)
-    'rsync gawel@srv:"~/p0rn" .'
+    'rsync gawel@srv:~/p0rn .'
 
 


### PR DESCRIPTION
currently with chut, we can't pass args with spaces unless shell=True is passed
to the command:

    >>> python("""-c 'print "a            b"'""") >1
    ERROR:chut:File "<string>", line 1
        'print
             ^
    SyntaxError: EOL while scanning string literal
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/Users/glehmann/Library/Python/2.7/lib/python/site-packages/chut/__init__.py", line 466, in __gt__
        return self._write(filename, 'wb+')
      File "/Users/glehmann/Library/Python/2.7/lib/python/site-packages/chut/__init__.py", line 523, in _write
        self._raise(output=output)
      File "/Users/glehmann/Library/Python/2.7/lib/python/site-packages/chut/__init__.py", line 547, in _raise
        raise OSError(self.commands_line, output.stderr)
    OSError: [Errno python -c 'print "a b"'] File "<string>", line 1
        'print
             ^
    SyntaxError: EOL while scanning string literal

passing several arguments helps - there are no exception, but the output is not
the expected one

    >>> python("-c", 'print "a            b"') >1

    ''

even with shell=True, the output is not the as expected - the number of spaces
is not preserved:

    >>> python("""-c 'print "a            b"'""", shell=True) >1
    a b
    ''

Now when shell=True nothing is split by chut - the shell do all the splitting
job - and passing several args is not allowed.
Args are split with shlex to preserve the contentinside the quotes.
lists are allowed in the arguments and their content is passed unchanged to
execve.

  echo(["a    b", "c"], "d    e")        # echo "a   b" "c" "d" "e"
  echo("a    b c d    e")                # echo "a" "b" "c" "d" "e"
  echo("'a    b' c d    e")              # echo "a    b" "c" "d" "e"
  echo("'a    b' c d    e", sh=true)     # echo "a    b" "c" "d" "e"
  echo("a    b", "c", "d    e", sh=True) # raise exception, too much args