### PR TITLE
check the status of the command in __str__ and __iter__ and raise when the command has failed

### DIFF
--- a/chut/__init__.py
+++ b/chut/__init__.py
@@ -473,6 +473,8 @@ class Pipe(object):
         eol = six.PY3 and '\n' or b'\n'
         for line in self.stdout:
             yield self._decode(line).rstrip(eol)
+        if self.failed:
+            self._raise(output=self._get_stdout(''))
 
     def __call__(self, **kwargs):
         if self._done and self._stdout is not None:
@@ -498,7 +500,11 @@ class Pipe(object):
             self._stdout = output
         return output
 
-    __str__ = __call__
+    def __str__(self):
+        output = self.__call__()
+        if self.failed:
+            self._raise(output=output)
+        return output
 
     def __gt__(self, filename):
         return self._write(filename, 'wb+')


### PR DESCRIPTION
this avoids silent failures in code like:

```
for commit in git("git rev-parse master..mybranch"):
    ...
```

or

```
content = str(git("show"))
```

a failure - like a wrong dir, wrong branch name, ... - appears simply as an
empty result, and thus forces to run a check before iterating over the results:

```
gitcmd = git("git rev-parse master..mybranch")
if gitcmd:
    # ok, we can get the result
    for gitcmd:
        ...
else:
    # raise the error
    gitcmd >1
```

note that it is still quite easy to ignore the failure check with **call**:

```
for commit in git("git rev-parse master..mybranch")().splitlines():
    ...

content = git("show")()
```
